### PR TITLE
Update pyproj to VS 2017

### DIFF
--- a/{{cookiecutter.root_folder}}/BatchPythonWithCSConfig.pyproj
+++ b/{{cookiecutter.root_folder}}/BatchPythonWithCSConfig.pyproj
@@ -13,10 +13,6 @@
     <OutputPath>.</OutputPath>
     <Name>BatchPythonWithCSConfig</Name>
     <RootNamespace>BatchSamples</RootNamespace>
-    <InterpreterId>
-    </InterpreterId>
-    <InterpreterVersion>
-    </InterpreterVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,12 +50,7 @@
     <Compile Include="common\helpers.py" />
     <Compile Include="common\__init__.py" />
   </ItemGroup>
-  <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <PtvsTargetsFile>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets</PtvsTargetsFile>
-  </PropertyGroup>
-  <Import Condition="Exists($(PtvsTargetsFile))" Project="$(PtvsTargetsFile)" />
-  <Import Condition="!Exists($(PtvsTargetsFile))" Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
   <!-- Uncomment the CoreCompile target to enable the Build command in
        Visual Studio and specify your pre- and post-build commands in
        the BeforeBuild and AfterBuild targets below. -->


### PR DESCRIPTION
VS 2017 with Python and Cookiecutter explorer support is now officially out.